### PR TITLE
Allow version to be omitted in AvetmissData::Package initialisation

### DIFF
--- a/lib/avetmiss_data/package.rb
+++ b/lib/avetmiss_data/package.rb
@@ -25,6 +25,7 @@ class AvetmissData::Package
   }.merge(FILES_MAP)
 
   KNOWN_VERSIONS = [:v6, :v7, :v8]
+  DEFAULT_VERSION = :v8
 
   attr_accessor :activity_year
   attr_accessor :organisation_code
@@ -41,9 +42,9 @@ class AvetmissData::Package
   attr_accessor :qual_completion_stores
   attr_accessor :version
 
-  def initialize(attributes = {}, version: :v8)
+  def initialize(attributes = {})
+    self.version = attributes.fetch(:version, DEFAULT_VERSION)
     self.attributes = attributes
-    self.version = version
     self.submission_stores = []
     self.rto_stores = []
     self.rto_delivery_location_stores = []

--- a/lib/avetmiss_data/version.rb
+++ b/lib/avetmiss_data/version.rb
@@ -1,3 +1,3 @@
 module AvetmissData
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -3,6 +3,52 @@ require 'spec_helper'
 describe AvetmissData::Package do
   let(:package) { AvetmissData::Package.new }
 
+  describe 'initialize' do
+    context 'when attributes provided' do
+      context 'and version provided' do
+        let(:package) { AvetmissData::Package.new(activity_year: 2014, version: :v7) }
+
+        it 'assigns provided attributes' do
+          expect(package.activity_year).to eq(2014)
+        end
+
+        it 'assigns provided version' do
+          expect(package.version).to eq(:v7)
+        end
+      end
+
+      context 'and version omitted' do
+        let(:package) { AvetmissData::Package.new(activity_year: 2014) }
+
+        it 'assigns provided attributes' do
+          expect(package.activity_year).to eq(2014)
+        end
+
+        it 'uses default version' do
+          expect(package.version).to eq(:v8)
+        end
+      end
+    end
+
+    context 'when attributes omitted' do
+      context 'and version provided' do
+        let(:package) { AvetmissData::Package.new(version: :v7) }
+
+        it 'assigns provided version' do
+          expect(package.version).to eq(:v7)
+        end
+      end
+
+      context 'and version omitted' do
+        let(:package) { AvetmissData::Package.new() }
+
+        it 'uses default version' do
+          expect(package.version).to eq(:v8)
+        end
+      end
+    end
+  end
+
   context '<<' do
     let!(:enrolment_store) { AvetmissData::Stores::V7::Enrolment.new }
     before { package.enrolment_stores << enrolment_store }


### PR DESCRIPTION
Previous update added the version keyword to `Package#initialize`. This caused the following ways of initialising the package to fail:

```
AvetmissData::Package.new(activity_year: 2014)
AvetmissData::Package.new({activity_year: 2014})
AvetmissData::Package.new(activity_year: 2014, version: :v8)
```

The only way to initialise the package was to provide attributes and version as below:

```
AvetmissData::Package.new({activity_year: 2014}, version: :v8)
```

This update allows all of the above initialisations.
