### PR TITLE
Add course stores to aggregated nat package

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    avetmiss_data (2.0.0)
+    avetmiss_data (2.0.2)
       activesupport
       zipruby
 
@@ -57,3 +57,6 @@ DEPENDENCIES
   rake (~> 10.1)
   rspec (~> 2.14)
   simplecov
+
+BUNDLED WITH
+   1.10.6

--- a/lib/avetmiss_data/package.rb
+++ b/lib/avetmiss_data/package.rb
@@ -20,9 +20,9 @@ class AvetmissData::Package
     course_stores: "NAT00030A",
   }.merge(FILES_MAP)
 
-  AGGREGATE_FILES_MAP = {
+  V6_V7_AGGREGATE_FILES_MAP = {
     submission_stores: "NAT00005"
-  }.merge(FILES_MAP)
+  }.merge(V6_V7_FILES_MAP)
 
   KNOWN_VERSIONS = [:v6, :v7, :v8]
   DEFAULT_VERSION = :v8
@@ -148,7 +148,7 @@ class AvetmissData::Package
   end
 
   def to_aggregate_zip_file
-    generate_zip_file(AGGREGATE_FILES_MAP)
+    generate_zip_file(V6_V7_AGGREGATE_FILES_MAP)
   end
 
   def each_store(&block)

--- a/lib/avetmiss_data/version.rb
+++ b/lib/avetmiss_data/version.rb
@@ -1,3 +1,3 @@
 module AvetmissData
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -124,8 +124,13 @@ describe AvetmissData::Package do
         File.open(temp_file.path, 'wb:ASCII-8BIT') { |f| f << package.to_aggregate_zip_file }
       end
 
-      it 'contains standard files plus submission file for STA aggregate submission' do
-        expect(file_names).to match_array(AvetmissData::Package::AGGREGATE_FILES_MAP.values)
+      context 'for a v7 package' do
+        it 'contains each store type' do
+          expect(file_names.count).to eq(11)
+        end
+        it 'contains standard files plus submission file for STA aggregate submission' do
+          expect(file_names).to match_array(AvetmissData::Package::V6_V7_AGGREGATE_FILES_MAP.values)
+        end
       end
     end
   end


### PR DESCRIPTION
The update to support v8 meant course stores were being omitted from aggregated nat packages. This change re-includes course stores for v6/v7 packages, 
This will still need updating to support v8 packages