### PR TITLE
[AV-4072] Reduce line length of RTO store from 268 to 110

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    avetmiss_data (2.0.3)
+    avetmiss_data (2.0.4)
       activesupport
       zipruby
 

--- a/lib/avetmiss_data/stores/v8/rto.rb
+++ b/lib/avetmiss_data/stores/v8/rto.rb
@@ -2,7 +2,7 @@ class AvetmissData::Stores::V8::Rto < AvetmissData::Stores::V8::Base
   nat_file('NAT00010', {
     training_organisation_identifier: 0...10,
     training_organisation_name: 10...110,
-    extras: 268..-1
+    extras: 110..-1
   })
 
   alias_method :identifier, :training_organisation_identifier

--- a/lib/avetmiss_data/version.rb
+++ b/lib/avetmiss_data/version.rb
@@ -1,3 +1,3 @@
 module AvetmissData
-  VERSION = '2.0.3'
+  VERSION = '2.0.4'
 end

--- a/spec/fixtures/nat_files/v8/NAT00010.txt
+++ b/spec/fixtures/nat_files/v8/NAT00010.txt
@@ -1,1 +1,1 @@
-12345     JobReady Solutions                                                                                                                                                                                                                                                
+12345     JobReady Solutions                                                                                  


### PR DESCRIPTION
https://jobready.atlassian.net/browse/AV-4072

The spec says the line length is 268 but I believe this to be an error as the line actually ends at 110 with the last field. Even if the line length was 268, nothing corresponds to the gap between 110 and 268. If an AVETMISS zip file is processed with this gem it will populate `training_organisation_identifier` and `training_organisation_name` and nothing else irrespective of whether it is 110 or 268 (or more) line length for the rto store. However, it causes an out of range issue when building an rto store with the line length set to 268. Setting it to 110 fixes it and makes it consistent with all other stores.