### PR TITLE
Add delegators in base store to package for activity_year and organisation_code

### DIFF
--- a/lib/avetmiss_data/stores/base.rb
+++ b/lib/avetmiss_data/stores/base.rb
@@ -3,6 +3,8 @@ class AvetmissData::Stores::Base
   class_attribute :file_name, :parser, :builder, :attribute_names
   attr_accessor :line_number, :package
 
+  delegate :activity_year, :organisation_code, to: :package, prefix: true, allow_nil: true
+
   def self.nat_file(file_name, mapping)
     self.file_name = file_name
     self.parser = AvetmissData::Parser.new(mapping)

--- a/lib/avetmiss_data/version.rb
+++ b/lib/avetmiss_data/version.rb
@@ -1,3 +1,3 @@
 module AvetmissData
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end

--- a/spec/stores/base_spec.rb
+++ b/spec/stores/base_spec.rb
@@ -71,6 +71,48 @@ describe AvetmissData::Stores::Base do
     end
   end
 
+  context 'package_activity_year' do
+    subject { store.package_activity_year }
+
+    let(:store) { AvetmissData::Stores::V8::Enrolment.new(package: package) }
+
+    context 'where activity_year present on package' do
+      let(:package) { AvetmissData::Package.new(activity_year: 2015) }
+      it { should eq(2015) }
+    end
+
+    context 'where activity_year blank on package' do
+      let(:package) { AvetmissData::Package.new(activity_year: nil) }
+      it { should be_nil }
+    end
+
+    context 'where package does not exist' do
+      let(:store) { AvetmissData::Stores::V8::Enrolment.new }   # can't explicitly pass in package: nil
+      it { should be_nil }
+    end
+  end
+
+  context 'package_organisation_code' do
+    subject { store.package_organisation_code }
+
+    let(:store) { AvetmissData::Stores::V8::Enrolment.new(package: package) }
+
+    context 'where organisation_code present on package' do
+      let(:package) { AvetmissData::Package.new(organisation_code: 2015) }
+      it { should eq(2015) }
+    end
+
+    context 'where organisation_code blank on package' do
+      let(:package) { AvetmissData::Package.new(organisation_code: nil) }
+      it { should be_nil }
+    end
+
+    context 'where package does not exist' do
+      let(:store) { AvetmissData::Stores::V8::Enrolment.new }   # can't explicitly pass in package: nil
+      it { should be_nil }
+    end
+  end
+
   context '#package=' do
     let(:enrolment_store) { AvetmissData::Stores::V7::Enrolment.new }
     let(:package) { AvetmissData::Package.new }


### PR DESCRIPTION
AVETARS has references to `store.package.activity_year` and `store.package.organisation_code` which is a violation of the Law of Demeter so let stores know what activity year and organisation code they are for. More importantly, these fields are used in some validations and in trying to spec these validators in isolated, only having these values available through the package makes spec work difficult.